### PR TITLE
Update `resize.sh` to support nvme

### DIFF
--- a/doc_source/move-environment.md
+++ b/doc_source/move-environment.md
@@ -98,11 +98,20 @@ For more information about the preceding procedure, see [Changing the Instance T
      sleep 1
    done
    
+   DISK=/dev/xvda
+   FILESYSTEM=/dev/xvda1
+   
+   # Some instance types have nvme disk instead of xvda.
+   if [ ! -e "$DISK" ] && [ -e "/dev/nvme0n1" ]; then
+     DISK=/dev/nvme0n1
+     FILESYSTEM=/dev/nvme0n1p1
+   fi
+   
    # Rewrite the partition table so that the partition takes up all the space that it can.
-   sudo growpart /dev/xvda 1
+   sudo growpart $DISK 1
    
    # Expand the size of the file system.
-   sudo resize2fs /dev/xvda1
+   sudo resize2fs $FILESYSTEM
    ```
 
    For Ubuntu Server:
@@ -130,11 +139,20 @@ For more information about the preceding procedure, see [Changing the Instance T
      sleep 1
    done
    
+   DISK=/dev/xvda
+   FILESYSTEM=/dev/xvda1
+   
+   # Some instance types have nvme disk instead of xvda.
+   if [ ! -e "$DISK" ] && [ -e "/dev/nvme0n1" ]; then
+     DISK=/dev/nvme0n1
+     FILESYSTEM=/dev/nvme0n1p1
+   fi
+   
    # Rewrite the partition table so that the partition takes up all the space that it can.
-   sudo growpart /dev/xvda 1
+   sudo growpart $DISK 1
    
    # Expand the size of the file system.
-   sudo resize2fs /dev/xvda1
+   sudo resize2fs $FILESYSTEM
    ```
 
 1. From a terminal session in the IDE, switch to the directory that contains the `resize.sh` file\. Then run the following command, replacing 20 with the desired size in GiB to resize the Amazon EBS volume to\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When creating an environment using `m5.large` instance type, the default resize script doesn't work because the disk is nvme instead of xvda.

![image](https://user-images.githubusercontent.com/193136/78261198-23072080-7529-11ea-9ceb-e4461fdaccd8.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
