### PR TITLE
update keybinding for GoToCommand

### DIFF
--- a/doc_source/keybindings-default-apple-osx.md
+++ b/doc_source/keybindings-default-apple-osx.md
@@ -112,7 +112,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Command-E\|Command-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Command-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Command-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Command-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Command-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Command-Shift-E`   |   `outline`   | 

--- a/doc_source/keybindings-default-windows-linux.md
+++ b/doc_source/keybindings-default-windows-linux.md
@@ -112,7 +112,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Ctrl-E\|Ctrl-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Ctrl-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Ctrl-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Ctrl-Shift-E`   |   `outline`   | 

--- a/doc_source/keybindings-emacs-apple-osx.md
+++ b/doc_source/keybindings-emacs-apple-osx.md
@@ -112,7 +112,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Command-E\|Command-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Command-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Command-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Command-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Command-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Command-Shift-E`   |   `outline`   | 

--- a/doc_source/keybindings-emacs-windows-linux.md
+++ b/doc_source/keybindings-emacs-windows-linux.md
@@ -112,7 +112,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Ctrl-E\|Ctrl-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Ctrl-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Ctrl-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Ctrl-Shift-E`   |   `outline`   | 

--- a/doc_source/keybindings-sublime-apple-osx.md
+++ b/doc_source/keybindings-sublime-apple-osx.md
@@ -124,7 +124,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Command-E\|Command-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Command-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Command-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Command-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Command-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Command-Shift-R`   |   `outline`   | 

--- a/doc_source/keybindings-sublime-windows-linux.md
+++ b/doc_source/keybindings-sublime-windows-linux.md
@@ -124,7 +124,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Ctrl-E\|Ctrl-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Ctrl-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Ctrl-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Ctrl-R\|Ctrl-Shift-R`   |   `outline`   | 

--- a/doc_source/keybindings-vim-apple-osx.md
+++ b/doc_source/keybindings-vim-apple-osx.md
@@ -112,7 +112,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Command-E\|Command-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Command-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Command-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Command-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Command-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Command-Shift-E`   |   `outline`   | 

--- a/doc_source/keybindings-vim-windows-linux.md
+++ b/doc_source/keybindings-vim-windows-linux.md
@@ -112,7 +112,7 @@ See also [Working with Keybindings](settings-keybindings.md)\.
 | Description | Keybinding | Command | 
 | --- | --- | --- | 
 |  Show the **Go** window in **Go to Anything** mode  |   `Ctrl-E\|Ctrl-P`   |   `gotoanything`   | 
-|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.`   |   `gotocommand`   | 
+|  Show the **Go** window in **Go to Command** mode  |   `Ctrl-.|F1`   |   `gotocommand`   | 
 |  Show the **Go** window in **Go to File** mode\.  |   `Ctrl-O`   |   `gotofile`   | 
 |  Show the **Go** window in **Go to Symbol** mode\.  |   `Ctrl-Shift-O`   |   `gotosymbol`   | 
 |  Show the **Outline** window  |   `Ctrl-Shift-E`   |   `outline`   | 


### PR DESCRIPTION
`F1` now does the same as  `Ctrl-.`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
